### PR TITLE
100vwに関連する横スクロールバーの問題を修正

### DIFF
--- a/layout/_default/episode.html
+++ b/layout/_default/episode.html
@@ -5,8 +5,8 @@
     {{ partial "meta.html" . }}
   </head>
   <body>
+    {{ partial "header.html" . }}
     <div class="Container">
-      {{ partial "header.html" . }}
       <main class="Main">
         <h1>{{ .Title }}</h1>
         <audio
@@ -56,8 +56,8 @@
         {{ .Content }}
         {{ partial "aside.html" . }}
       </main>
-      {{ partial "footer.html" . }}
     </div>
+    {{ partial "footer.html" . }}
     {{ partial "script.html" . }}
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/layout/index.html
+++ b/layout/index.html
@@ -5,8 +5,8 @@
     {{ partial "meta.html" . }}
   </head>
   <body>
+    {{ partial "header.html" . }}
     <div class="Container">
-      {{ partial "header.html" . }}
       <main class="Main">
         {{ $paginator := .Paginate .Site.RegularPages }}
         <ul class="Episode">
@@ -19,8 +19,8 @@
         </ul>
         {{ partial "nav.html" . }}
       </main>
-      {{ partial "footer.html" . }}
     </div>
+    {{ partial "footer.html" . }}
     {{ partial "script.html" . }}
   </body>
 </html>

--- a/layout/partials/footer.html
+++ b/layout/partials/footer.html
@@ -1,51 +1,55 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/footer.css">
 <footer class="Footer">
-  <div class="Footer__Item">
-    <h2>About</h2>
-    <p><a href="https://twitter.com/strobofm">@strobofm</a> is a podcast by <a href="https://twitter.com/1000ch">@1000ch</a> focusing on the web, technology, gadget, productivity, automation. Please <a href="https://www.patreon.com/strobofm">become a patron</a> if you enjoy it.</p>
-    <a href="https://www.patreon.com/bePatron?u=9661402">
-      <img src="{{ .Site.BaseURL }}/img/patreon.png" width="217" height="51" alt="Become a Patron!">
-    </a>
-  </div>
-  <div class="Footer__Item">
-    <h2>Subscribe</h2>
-    <ul class="Subscribe">
-      <li class="Subscribe__Item">
-        <a href="https://itunes.apple.com/jp/podcast/id1312181476">
-          <img src="https://icongr.am/fontawesome/apple.svg?color=ffffff" alt="">
-          Apple Podcast で購読する
+  <div class="Container">
+    <div class="Footer__inner">
+      <div class="Footer__Item">
+        <h2>About</h2>
+        <p><a href="https://twitter.com/strobofm">@strobofm</a> is a podcast by <a href="https://twitter.com/1000ch">@1000ch</a> focusing on the web, technology, gadget, productivity, automation. Please <a href="https://www.patreon.com/strobofm">become a patron</a> if you enjoy it.</p>
+        <a href="https://www.patreon.com/bePatron?u=9661402">
+          <img src="{{ .Site.BaseURL }}/img/patreon.png" width="217" height="51" alt="Become a Patron!">
         </a>
-      </li>
-      <li class="Subscribe__Item">
-        <a href="https://podcasts.google.com/?feed=aHR0cHM6Ly9zdHJvYm8uZm0vaW5kZXgueG1s">
-          <img src="https://icongr.am/fontawesome/google.svg?color=ffffff" alt="">
-          Google Podcasts で購読する
-        </a>
-      </li>
-      <li class="Subscribe__Item">
-        <a href="https://open.spotify.com/show/23rv2wvTpTFsZTbLnuLJmx">
-          <img src="https://icongr.am/fontawesome/spotify.svg?color=ffffff" alt="">
-          Spotify で購読する
-        </a>
-      </li>
-      <li class="Subscribe__Item">
-        <a href="http://feeds.feedburner.com/strobofm">
-          <img src="https://icongr.am/fontawesome/rss.svg?color=ffffff" alt="">
-          RSS で購読する
-        </a>
-      </li>
-      <li class="Subscribe__Item">
-        <a href="https://twitter.com/strobofm">
-          <img src="https://icongr.am/fontawesome/twitter.svg?color=ffffff" alt="">
-          Twitter で購読する
-        </a>
-      </li>
-      <li class="Subscribe__Item">
-        <a href="https://facebook.com/strobofm">
-          <img src="https://icongr.am/fontawesome/facebook.svg?color=ffffff" alt="">
-          Facebook で購読する
-        </a>
-      </li>
-    </ul>
+      </div>
+      <div class="Footer__Item">
+        <h2>Subscribe</h2>
+        <ul class="Subscribe">
+          <li class="Subscribe__Item">
+            <a href="https://itunes.apple.com/jp/podcast/id1312181476">
+              <img src="https://icongr.am/fontawesome/apple.svg?color=ffffff" alt="">
+              Apple Podcast で購読する
+            </a>
+          </li>
+          <li class="Subscribe__Item">
+            <a href="https://podcasts.google.com/?feed=aHR0cHM6Ly9zdHJvYm8uZm0vaW5kZXgueG1s">
+              <img src="https://icongr.am/fontawesome/google.svg?color=ffffff" alt="">
+              Google Podcasts で購読する
+            </a>
+          </li>
+          <li class="Subscribe__Item">
+            <a href="https://open.spotify.com/show/23rv2wvTpTFsZTbLnuLJmx">
+              <img src="https://icongr.am/fontawesome/spotify.svg?color=ffffff" alt="">
+              Spotify で購読する
+            </a>
+          </li>
+          <li class="Subscribe__Item">
+            <a href="http://feeds.feedburner.com/strobofm">
+              <img src="https://icongr.am/fontawesome/rss.svg?color=ffffff" alt="">
+              RSS で購読する
+            </a>
+          </li>
+          <li class="Subscribe__Item">
+            <a href="https://twitter.com/strobofm">
+              <img src="https://icongr.am/fontawesome/twitter.svg?color=ffffff" alt="">
+              Twitter で購読する
+            </a>
+          </li>
+          <li class="Subscribe__Item">
+            <a href="https://facebook.com/strobofm">
+              <img src="https://icongr.am/fontawesome/facebook.svg?color=ffffff" alt="">
+              Facebook で購読する
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </footer>

--- a/layout/partials/footer.html
+++ b/layout/partials/footer.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/footer.css">
 <footer class="Footer">
   <div class="Container">
-    <div class="Footer__inner">
+    <div class="Footer__Inner">
       <div class="Footer__Item">
         <h2>About</h2>
         <p><a href="https://twitter.com/strobofm">@strobofm</a> is a podcast by <a href="https://twitter.com/1000ch">@1000ch</a> focusing on the web, technology, gadget, productivity, automation. Please <a href="https://www.patreon.com/strobofm">become a patron</a> if you enjoy it.</p>

--- a/layout/partials/header.html
+++ b/layout/partials/header.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/header.css">
 <header class="Header">
-  <div class="Header__Item">
+  <div class="Container">
     <h1 class="Header__Title">
       <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
     </h1>

--- a/layout/people/list.html
+++ b/layout/people/list.html
@@ -6,8 +6,8 @@
   </head>
   <body>
     {{ $term := .Data.Term }}
+    {{ partial "header.html" . }}
     <div class="Container">
-      {{ partial "header.html" . }}
       <main class="Main">
         <ul class="People">
           {{ range $key, $taxonomy := .Site.Taxonomies.people }}
@@ -51,8 +51,8 @@
           {{ end }}
         </ul>
       </main>
-      {{ partial "footer.html" . }}
     </div>
+    {{ partial "footer.html" . }}
     {{ partial "script.html" . }}
   </body>
 </html>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -40,6 +40,7 @@ html {
 }
 
 body {
+  min-height: 100vh;
   margin: 0;
   padding: 0;
   color: var(--light-color);

--- a/static/css/component.css
+++ b/static/css/component.css
@@ -1,13 +1,14 @@
 .Container {
   min-width: calc(var(--size-base) * 40);
-  max-width: calc(var(--size-base) * 80);
-  min-height: 100vh;
+  max-width: calc(var(--size-base) * 78);
   margin: 0 auto;
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .Main {
   min-height: calc(100vh - 400px);
-  padding: 32px 16px;
+  padding: 32px 0;
 }
 
 .Control {

--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -1,15 +1,18 @@
 .Footer {
-  display: flex;
-  flex-wrap: wrap;
   min-height: 200px;
-  margin: 0 calc((100vw - 100%) / -2);
-  padding: calc(var(--size-base) * 4) calc((100vw - 100%) / 2);
+  padding: calc(var(--size-base) * 4) 0;
   color: #fff;
   background-color: #333;
 }
 
+.Footer__inner {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -16px;
+}
+
 .Footer__Item {
-  width: calc(var(--size-base) * 40);
+  width: 50%;
   padding: 0 16px;
 }
 

--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -5,7 +5,7 @@
   background-color: #333;
 }
 
-.Footer__inner {
+.Footer__Inner {
   display: flex;
   flex-wrap: wrap;
   margin: 0 -16px;

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -1,8 +1,7 @@
 .Header {
   position: relative;
   height: 200px;
-  margin: 0 calc((100vw - 100%) / -2);
-  padding: calc(var(--size-base) * 4) calc((100vw - 100%) / 2);
+  padding: calc(var(--size-base) * 4) 0;
   background-color: #333;
   background-image:
     url("/img/background-cover.svg"),
@@ -15,10 +14,6 @@
 .Header a {
   text-decoration: none;
   color: #fff;
-}
-
-.Header__Item {
-  padding: 0 16px;
 }
 
 .Header__Title {


### PR DESCRIPTION
Macにおいて「スクロールバーの表示」を「常に表示」に設定している場合に、サイトが横スクロールできてしまう問題を修正しました。

![Macのシステム環境設定にある「一般」の「スクロールバーの表示」において「常に表示」という項目がある](https://user-images.githubusercontent.com/11547305/84979384-504b8e00-b16a-11ea-819b-29a35b32cea9.png)

![サイトを表示しているブラウザに横スクロールバーが表示されている](https://user-images.githubusercontent.com/11547305/84979693-03b48280-b16b-11ea-9242-35a9964b3388.png)

`100vw`にはスクロールバーの幅のサイズまで含まれているため、中央配置のためにネガティブ`margin`で`100vw`を利用している`Header`等の箇所がウィンドウの表示領域をはみ出してしまう問題が発生していました。（参考：「[CSSを書く前にスクロールバーを表示しよう](https://unformedbuilding.com/articles/consider-classic-scrollbar/)」）

中央配置は引き続き`Container`で行いつつ、各コンポーネント内にこれを入れ子にして`100vw`を利用しないよう変更する形で対応しました。